### PR TITLE
Mention correct config file

### DIFF
--- a/doc_src/tutorial.hdr
+++ b/doc_src/tutorial.hdr
@@ -534,7 +534,7 @@ To prepend to `$PATH`, you can write:
 >_ set PATH /new/path $PATH
 \endfish
 
-You can do so directly in `fish.config`, like you might do in other shells with `.profile`. See [this example](#path_example).
+You can do so directly in `config.fish`, like you might do in other shells with `.profile`. See [this example](#path_example).
 
 A faster way is to modify the `$fish_user_paths` [universal variable](#tut_universal), which is automatically prepended to `$PATH`. For example, to permanently add `/usr/local/bin` to your `$PATH`, you could write:
 
@@ -542,7 +542,7 @@ A faster way is to modify the `$fish_user_paths` [universal variable](#tut_unive
 >_ set -U fish_user_paths /usr/local/bin $fish_user_paths
 \endfish
 
-The advantage is that you don't have to go mucking around in files: just run this once at the command line, and it will affect the current session and all future instances too. (Note: you should NOT add this line to `fish.config`. If you do, the variable will get longer each time you run fish!)
+The advantage is that you don't have to go mucking around in files: just run this once at the command line, and it will affect the current session and all future instances too. (Note: you should NOT add this line to `config.fish`. If you do, the variable will get longer each time you run fish!)
 
 \section tut_startup Startup (Where's .bashrc?)
 


### PR DESCRIPTION
While the tutorial explains how to set the `PATH` variable, it mentions the file `fish.config` but it should be `config.fish`.